### PR TITLE
pass dt to diffusive_utils and use it for time parameterization

### DIFF
--- a/src/python_routing_v02/troute/routing/diffusive_utils.py
+++ b/src/python_routing_v02/troute/routing/diffusive_utils.py
@@ -793,30 +793,30 @@ def unpack_output(pynw, ordered_reaches, out_q, out_elv):
         for rch in ordered_reaches[o]:
 
             rch_segs = rch[1]["segments_list"]
-            rch_list.extend(rch_segs)
+            rch_list.extend(rch_segs[:-1])
 
             j = reach_heads.index(rch[0])
 
             if i == 1:
-                dat_all = np.empty((len(rch_segs), nts * 3))
+                dat_all = np.empty((len(rch_segs)-1, nts * 3))
                 dat_all[:] = np.nan
                 # flow result
-                dat_all[:, ::3] = np.transpose(np.array(out_q[:, 0 : len(rch_segs), j]))
+                dat_all[:, ::3] = np.transpose(np.array(out_q[:, 1 : len(rch_segs), j]))
                 # elevation result
                 dat_all[:, 2::3] = np.transpose(
-                    np.array(out_elv[:, 0 : len(rch_segs), j])
+                    np.array(out_elv[:, 1 : len(rch_segs), j])
                 )
 
             else:
-                dat_all_c = np.empty((len(rch_segs), nts * 3))
+                dat_all_c = np.empty((len(rch_segs)-1, nts * 3))
                 dat_all_c[:] = np.nan
                 # flow result
                 dat_all_c[:, ::3] = np.transpose(
-                    np.array(out_q[:, 0 : len(rch_segs), j])
+                    np.array(out_q[:, 1 : len(rch_segs), j])
                 )
                 # elevation result
                 dat_all_c[:, 2::3] = np.transpose(
-                    np.array(out_elv[:, 0 : len(rch_segs), j])
+                    np.array(out_elv[:, 1 : len(rch_segs), j])
                 )
                 # concatenate
                 dat_all = np.concatenate((dat_all, dat_all_c))

--- a/src/python_routing_v02/troute/routing/diffusive_utils.py
+++ b/src/python_routing_v02/troute/routing/diffusive_utils.py
@@ -428,7 +428,8 @@ def diffusive_input_data_v02(
     initial_conditions,
     upstream_results,
     qts_subdivisions,
-    nsteps
+    nsteps,
+    dt
 ):
     """
     Build input data objects for diffusive wave model
@@ -454,14 +455,14 @@ def diffusive_input_data_v02(
     """
 
     # diffusive time steps info.
-    dt_ql_g = geo_data[0,0] * qts_subdivisions
-    dt_ub_g = geo_data[0,0] * qts_subdivisions # TODO: make this timestep the same as the simulation timestep
-    dt_db_g = geo_data[0,0] * qts_subdivisions # TODO: make this timestep the same as the simulation timestep
-    saveinterval_g = geo_data[0,0]
-    saveinterval_ev_g = geo_data[0,0]
-    dtini_g = geo_data[0,0]
+    dt_ql_g = dt * qts_subdivisions
+    dt_ub_g = dt * qts_subdivisions # TODO: make this timestep the same as the simulation timestep
+    dt_db_g = dt * qts_subdivisions # TODO: make this timestep the same as the simulation timestep
+    saveinterval_g = dt
+    saveinterval_ev_g = dt
+    dtini_g = dt
     t0_g = 0.0  # simulation start hr **set to zero for Fortran computation
-    tfin_g = (geo_data[0,0] * nsteps)/60/60
+    tfin_g = (dt * nsteps)/60/60
     
     # USGS data related info.
     usgsID = diffusive_parameters.get("usgsID", None)

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
@@ -161,7 +161,8 @@ cpdef object compute_diffusive_tst(
         np.asarray(initial_conditions),
         upstream_results,
         qts_subdivisions,
-        nsteps
+        nsteps,
+        dt
         )
 
     # unpack/declare diffusive input variables


### PR DESCRIPTION
Rather than taking the model timestep from the geo_data array, we can get it directly from yaml and use it to parameterize diffusive wave time. Also, I fixed a bug in the reformatting of the diffusive code output (out_q) to the flowveldepth array structure. 